### PR TITLE
feat: add zoom link

### DIFF
--- a/templates/meeting_base_diag
+++ b/templates/meeting_base_diag
@@ -6,6 +6,6 @@ GROUP_NAME="Diagnostics WorkGroup"
 AGENDA_TAG=diag-agenda
 JOINING_INSTRUCTIONS="
 
-* link for participants: Will be added a few minutes before meeting starts
+* link for participants: https://zoom.us/j/466707925
 * For those who just want to watch: 
 * youtube admin page: https://www.youtube.com/my_live_events?filter=scheduled"


### PR DESCRIPTION
Recurring Zoom links stay the same except if the meeting is not started for 365 days.
Unfortunately, Zoom doesn't support meeting aliases for nonpersonal meetings.