### PR TITLE
Update meeting templates for standing issues

### DIFF
--- a/templates/minutes_base_commcomm
+++ b/templates/minutes_base_commcomm
@@ -15,6 +15,8 @@ $OBSERVERS$
 ## Agenda
 
 ## Announcements
+
+## CPC and Board Meeting Updates
  
 *Extracted from **cc-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
 

--- a/templates/minutes_base_tsc
+++ b/templates/minutes_base_tsc
@@ -21,7 +21,7 @@ $OBSERVERS$
 
 $AGENDA_CONTENT$
 
-### Strategic Initiatives
+## Strategic Initiatives
 
 ## Upcoming Meetings
 

--- a/templates/minutes_base_tsc
+++ b/templates/minutes_base_tsc
@@ -14,12 +14,14 @@ $OBSERVERS$
 ## Agenda
 
 ### Announcements
+
+## CPC and Board Meeting Updates
  
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 
 $AGENDA_CONTENT$
 
-## Q&A, Other
+## Strategic Initiatives
 
 ## Upcoming Meetings
 

--- a/templates/minutes_base_tsc
+++ b/templates/minutes_base_tsc
@@ -15,7 +15,7 @@ $OBSERVERS$
 
 ### Announcements
 
-## CPC and Board Meeting Updates
+### CPC and Board Meeting Updates
  
 *Extracted from **tsc-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
 

--- a/templates/minutes_base_tsc
+++ b/templates/minutes_base_tsc
@@ -21,7 +21,7 @@ $OBSERVERS$
 
 $AGENDA_CONTENT$
 
-## Strategic Initiatives
+### Strategic Initiatives
 
 ## Upcoming Meetings
 


### PR DESCRIPTION
Instead of having permanently open issues just so the tooling can add
stuff to the agenda, include permanent standing issues in the templates.

While we're at it, get rid of "Q&A, Other" from TSC meeting because we
don't do Q&A anymore and "Other" seems lose-able.

Closes: https://github.com/nodejs/admin/issues/395
Closes: https://github.com/nodejs/TSC/issues/423