### PR TITLE
update link for meeting in commcomm template

### DIFF
--- a/templates/meeting_base_commcomm
+++ b/templates/meeting_base_commcomm
@@ -6,7 +6,7 @@ GROUP_NAME="Community Committee"
 AGENDA_TAG=cc-agenda
 JOINING_INSTRUCTIONS="
 
-* Link for participants: https://zoom.us/j/527273462
+* Link for participants: https://zoom.us/j/523381536
 * For those who just want to watch: https://www.youtube.com/channel/UCQPYJluYC_sn_Qz_XE-YbTQ
 
 ---


### PR DESCRIPTION
New url as last one had expired.