### PR TITLE
[DO NOT MERGE] add HackMD integration

### DIFF
--- a/lib/create-gh-issue.js
+++ b/lib/create-gh-issue.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Creates a callback function which accepts an issue `body` argument.
+ * `body` will be used in a new GitHub issue containing meeting information.
+ */
+exports.createGithubIssueCallback = (title, meetingProperties, done) => (err, body) => {
+  if (err) {
+    err.message = `Failed to upload minutes file:\n${err.message}`;
+    return done(err);
+  }
+  github.issues.create({
+    owner: meetingProperties.USER.replace(/"/g, ''),
+    repo: meetingProperties.REPO.replace(/"/g, ''),
+    title: title,
+    body,
+    assignee: 'mhdawson',
+  });
+  done();
+};

--- a/lib/google-docs.js
+++ b/lib/google-docs.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const gdriveWrapper = require('google-drive-wrapper');
+
+/**
+ * Creates a new Google doc from the meeting template.
+ * Calls `done(err, body)` with the body of a to-be-created GitHub issue.
+ */
+exports.upload = (
+  minutesDocName,
+  {title, googleAuthToken, googleApi, newIssue} = {},
+  done
+) => {
+  const wrapper = new gdriveWrapper(googleAuthToken, googleApi, 'dummy');
+  wrapper.getMetaForFilename('/nodejs-meetings', function (err, parentMeta) {
+    if (err !== null) {
+      return done(
+        new Error('Directory called "nodejs-meetings" does not exist, exiting')
+      );
+    }
+
+    wrapper.uploadFile(
+      title,
+      minutesDocName,
+      {
+        parent: parentMeta.id,
+        compress: false,
+        encrypt: false,
+        convert: true,
+        mimeType: 'application/vnd.google-apps.document',
+      },
+      (meta) => {
+        newIssue = newIssue
+          .toString()
+          .replace(
+            /\* \*\*Minutes Google Doc\*\*: <>/,
+            '* Minutes Google Doc: <https://docs.google.com/document/d/' +
+              meta.id +
+              '/edit>'
+          )
+          .replace(/\* _Previous Minutes Google Doc: <>_/, '');
+        done(null, newIssue);
+      }
+    );
+  });
+};

--- a/lib/hackmd.js
+++ b/lib/hackmd.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const {execSync, spawnSync} = require('child_process');
+
+/**
+ * Creates a new HackMD doc from the meeting template.
+ * Calls `done(err, body)` with the body of a to-be-created GitHub issue.
+ * 
+ * For this to work, `process.env` must contain `CMD_CLI_ID=<email>` where `<email>` is
+ * a HackMD username, and `CMD_CLI_PASSWORD=<password>` where `<password>` is the HackMD
+ * user's password.
+ * 
+ * @see https://npm.im/@hackmd/codimd-cli
+ */
+exports.upload = (filepath, {newIssue: body} = {}, done) => {
+  console.log('Logging in to HackMD...');
+  try {
+    // this places a token in ~/.codimd/cookies.json
+    spawnSync('node', ['node_modules/.bin/codimd-cli', 'login']);
+  } catch (err) {
+    return done(err);
+  }
+  console.log('Importing minutes doc...');
+  try {
+    const result = execSync(
+      `cat "${filepath}" | node_modules/.bin/codimd-cli`
+    ).toString('utf8');
+    // the result will be a string containing a URL.  grab it
+    const url = result.match(/(https:.+?)[\s\S]/)[1];
+    if (!url) {
+      return done(new Error(`Could not parse URL from codimd-cli result:\n${result}`));
+    }
+    body = body
+      .toString()
+      .replace(
+        /\* \*\*Minutes(?:[\s\S]+?)Doc\*\*: <>/,
+        `* Minutes HackMD Doc: ${url}`
+      )
+      .replace(/\* _Previous Minutes(?:[\s\S]+?)Doc: <>_/, '');
+    done(null, body);
+  } catch (err) {
+    done(err);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "create-node-meeting-artifacts",
   "version": "0.0.1",
   "description": "Creates issue and minutes doc for node meeting",
-  "main": "index.js",
+  "main": "lib/create-node-meeting-artifacts.js",
   "bin": {
     "create-meeting": "./bin/create-meeting"
   },
   "dependencies": {
+    "@hackmd/codimd-cli": "^1.0.3",
     "ghauth": "^3.2.1",
     "github": "^11.0.0",
     "google-auth-wrapper": "^0.5.0",
-    "google-calendar": "^1.3.2",
     "google-drive-wrapper": "^0.6.0",
     "make-node-meeting": "^1.0.11",
     "node-meeting-agenda": "^1.0.4",

--- a/templates/minutes_base_tooling
+++ b/templates/minutes_base_tooling
@@ -1,21 +1,20 @@
+USE_HACKMD=1
+
 # $TITLE$
 
 ## Links
 
-* **Recording**:  
+* **Recording**: $RECORDING_URL$
 * **GitHub Issue**: $GITHUB_ISSUE$
-* **Minutes Google Doc**: $MINUTES_DOC$
+* **Minutes Doc**: $MINUTES_DOC$
 
 ## Present
 
 $INVITED$
-$OBSERVERS$
 
 ## Agenda
 
-## Announcements
- 
-*Extracted from **tooling-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+> Extracted from issues labeled `tooling-agenda` in the [Node.js Tooling Group issue tracker](https://github.com/nodejs/tooling/issues) prior to the meeting.
 
 $AGENDA_CONTENT$
 
@@ -23,7 +22,9 @@ $AGENDA_CONTENT$
 
 ## Upcoming Meetings
 
-* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+Node.js Tooling Group meetings occur every two (2) weeks.
+
+* See the [Node.js Foundation Calendar](https://nodejs.org/calendar)
 
 Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.
 


### PR DESCRIPTION
This PR should allow Node.js groups to manage meeting minutes on [HackMD](https://hackmd.io).  Instead of a Google Doc, the script will create a document based on the template on HackMD, and use the resulting URL in the GitHub issue associated with the meeting.

To enable this behavior:

1. Put `USE_HACKMD=1` at the top of your group's issue template file (in `templates/`).
2. `process.env` must contain `CMD_CLI_ID=<email>` where `<email>` is a HackMD login
3. `process.env` must contain `CMD_CLI_ID=<password>` where `<password>` is the user's HackMD password

Nuts & bolts:

- I split `create-node-meeting-artifacts.js` into several different files, because it was difficult to test
- The script now either imports `lib/google-docs.js` or `lib/hackmd.js` depending on whether `USE_HACKMD` is present in the template. Both of these export a function `upload`
- `lib/create-gh-issue.js` exports a function which returns a callback.  `upload` is given this callback, since the issue cannot be created until the minutes document has a URL.
- Added [`@hackmd/codimd-cli`](https://npm.im/@hackmd/codimd-cli)
- Removed unused [`google-calendar`](https://npm.im/google-calendar)