### PR TITLE
templates: loaders team

### DIFF
--- a/TEMPLATES_DOCUMENTATION.md
+++ b/TEMPLATES_DOCUMENTATION.md
@@ -2,7 +2,7 @@ This document contains empty versions of each template needed to successfully cr
 
 There are only four variables in the documents that _need_ to be changed:
 
-- **`<name>`:** The name of the Committee, Working Group, Initiative, or Team that meeting artifacts are being creatd for.
+- **`<name>`:** The name of the Committee, Working Group, Initiative, or Team that meeting artifacts are being created for.
 - **`<shortname>`:** The abbreviated or shortened name for a group, used in each filename to connect associated files together.
 - **`<team_name>`:** The name of the GitHub team in the Node.js org.
 - **`<calendar event name>`:** The name of calendar events that mark the group's meeting date/time.

--- a/templates/invited_loaders
+++ b/templates/invited_loaders
@@ -1,0 +1,1 @@
+* Loaders team: @nodejs/loaders

--- a/templates/meeting_base_loaders
+++ b/templates/meeting_base_loaders
@@ -1,0 +1,8 @@
+CALENDAR_FILTER="Loaders Team Meeting"
+CALENDAR_ID="nodejs.org_nr77ama8p7d7f9ajrpnu506c98@group.calendar.google.com"
+USER="nodejs"
+REPO="loaders"
+GROUP_NAME="Loaders Team"
+JOINING_INSTRUCTIONS="* link for participants: <https://zoom.us/j/656987750>
+
+* For those who just want to watch: <https://www.youtube.com/c/nodejs+foundation/live>"

--- a/templates/minutes_base_loaders
+++ b/templates/minutes_base_loaders
@@ -1,0 +1,18 @@
+# $TITLE$
+
+## Links
+
+* **Recording**:
+* **GitHub Issue**: $GITHUB_ISSUE$
+
+## Present
+
+$INVITED$
+
+## Agenda
+
+## Announcements
+
+*Extracted from **loaders-agenda** labeled issues and pull requests from the **nodejs org** prior to the meeting.
+
+$AGENDA_CONTENT$


### PR DESCRIPTION
Add templates for the new Loaders team.

I’ll probably need another PR later for a new Zoom link but hopefully we can use this one for now.