### PR TITLE
remove irc mention from TSC meeting template

### DIFF
--- a/templates/meeting_base_tsc
+++ b/templates/meeting_base_tsc
@@ -13,7 +13,6 @@ Regular password
 
 We stream our conference call straight to YouTube so anyone can listen to it live, it should start playing at **<https://www.youtube.com/c/nodejs+foundation/live>** when we turn it on. There's usually a short cat-herding time at the start of the meeting and then occasionally we have some quick private business to attend to before we can start recording & streaming. So be patient and it should show up.
 
-If you'd like to interact, we have a Q/A session scheduled at the end of the meeting if you'd like us to discuss anything in particular. @nodejs/collaborators in particular if there's anything you need from the TSC that's not worth putting on as a separate agenda item, this is a good place for that.
 
 ---
 

--- a/templates/meeting_base_tsc
+++ b/templates/meeting_base_tsc
@@ -13,7 +13,7 @@ Regular password
 
 We stream our conference call straight to YouTube so anyone can listen to it live, it should start playing at **<https://www.youtube.com/c/nodejs+foundation/live>** when we turn it on. There's usually a short cat-herding time at the start of the meeting and then occasionally we have some quick private business to attend to before we can start recording & streaming. So be patient and it should show up.
 
-Many of us will be on IRC in #node-dev on Freenode if you'd like to interact, we have a Q/A session scheduled at the end of the meeting if you'd like us to discuss anything in particular. @nodejs/collaborators in particular if there's anything you need from the TSC that's not worth putting on as a separate agenda item, this is a good place for that.
+If you'd like to interact, we have a Q/A session scheduled at the end of the meeting if you'd like us to discuss anything in particular. @nodejs/collaborators in particular if there's anything you need from the TSC that's not worth putting on as a separate agenda item, this is a good place for that.
 
 ---
 


### PR DESCRIPTION
I don't have statistics to back it up, but I don't believe the statement that "many of us will be available on IRC during the meeting" is still true. We also don't typically bring up questions from IRC during meetings, so the statement is inaccurate and could lead the live meeting audience to ask questions in the wrong place. Therefore removing it seems like a good idea.