### PR TITLE
Add Dates and Reminders to CPC meeting template

### DIFF
--- a/templates/minutes_base_cross_project_council
+++ b/templates/minutes_base_cross_project_council
@@ -24,6 +24,11 @@ $AGENDA_CONTENT$
 
 Are there any initiatives or agenda items that we should use a working session to further progress on?
 
+## Dates and Reminders
+
+Please review regularly our list of dates and reminders:
+https://github.com/openjs-foundation/cross-project-council/blob/main/Dates-and-Reminders.md
+
 ## Q&A, Other
 
 ## Upcoming Meetings


### PR DESCRIPTION
This will help us to stay ahead of elections and other important dates and reminders.