### PR TITLE
Allow adding a label to the generated GitHub issue itself

### DIFF
--- a/TEMPLATES_DOCUMENTATION.md
+++ b/TEMPLATES_DOCUMENTATION.md
@@ -8,6 +8,7 @@ There are only four variables in the documents that _need_ to be changed:
 - **`<calendar event name>`:** The name of calendar events that mark the group's meeting date/time.
 - **`<repo>`:** The repository of the group.
 - **`<agenda-label>`:** The label for which to search the Node.js GitHub organization, to add items to the group's agenda.
+- **`<issue-label>`:** an optional label for the created issue itself.
 - **`<observer>`:** Name of an observer in a group's meetings.
 
 # Invited

--- a/create-node-meeting-artifacts.js
+++ b/create-node-meeting-artifacts.js
@@ -141,12 +141,14 @@ ghauth(authOptions, (err, authData) => {
                   /\* \*\*Minutes Google Doc\*\*: <>/,
                   '* Minutes Google Doc: <https://docs.google.com/document/d/' + meta.id + '/edit>');
               newIssue = newIssue.replace(/\* _Previous Minutes Google Doc: <>_/,'');
+              let issueLabel = (meetingProperties.ISSUE_LABEL || '').replace(/"/g, '');
                 github.issues.create({
                 owner: meetingProperties.USER.replace(/"/g, ''),
                 repo: meetingProperties.REPO.replace(/"/g, ''),
                 title: title,
                 body: newIssue,
-                assignee: "mhdawson"
+                assignee: "mhdawson",
+                labels: issueLabel ? [issueLabel] : undefined
               });
             }
           });

--- a/templates/meeting_base_cross_project_council
+++ b/templates/meeting_base_cross_project_council
@@ -7,6 +7,7 @@ HOST="OpenJS Foundation"
 REPO="cross-project-council"
 GROUP_NAME="Cross Project Council"
 AGENDA_TAG=cross-project-council-agenda
+ISSUE_LABEL=cpc-meeting
 JOINING_INSTRUCTIONS="
 
 link for participants: Zoom link: <https://zoom.us/j/920010234>


### PR DESCRIPTION
Allows adding an optional label to the generated GitHub issue itself.
Adds the `cpc-meeting` label to Cross Project Council meetings.