### PR TITLE
Add emoji legend to build meeting issues

### DIFF
--- a/templates/meeting_base_build
+++ b/templates/meeting_base_build
@@ -7,4 +7,16 @@ JOINING_INSTRUCTIONS="
 
 * link for participants: <https://zoom.us/j/715960833>
 * For those who just want to watch: We stream our conference call straight to YouTube so anyone can listen to it live, it should start playing at <https://www.youtube.com/c/nodejs+foundation/live> when we turn it on. There's usually a short cat-herding time at the start of the meeting and then occasionally we have some quick private business to attend to before we can start recording & streaming. So be patient and it should show up.
-* youtube admin page: <https://www.youtube.com/my_live_events?filter=scheduled>"
+* youtube admin page: <https://www.youtube.com/my_live_events?filter=scheduled>
+
+---
+
+**Invitees**
+
+Please use the following emoji reactions in this post to indicate your
+availability.
+
+* :+1: - Attending
+* :-1: - Not attending
+* :confused: - Not sure
+"


### PR DESCRIPTION
For consistency with other meetings, add the section explaining the emoji's to react with to indicate whether invitees are intending to attend the meeting to the build meeting issues.

cc @nodejs/build 