### PR TITLE
Remove fhinkel from meeting list

### DIFF
--- a/templates/invited_tsc
+++ b/templates/invited_tsc
@@ -5,7 +5,6 @@
 * Сковорода Никита Андреевич @ChALkeR (TSC)
 * Colin Ihrig @cjihrig (TSC)
 * Danielle Adams @danielleadams (TSC)
-* Franziska Hinkelmann @fhinkel (TSC)
 * Geoffrey Booth @GeoffreyBooth (TSC)
 * Gireesh Punathil @gireeshpunathil (TSC)
 * James Snell @jasnell (TSC)


### PR DESCRIPTION
We'll probably want to add everyone on the regular member list back in, but let's do that in a separate PR.