### PR TITLE
Update invited_tsc

### DIFF
--- a/templates/invited_tsc
+++ b/templates/invited_tsc
@@ -19,7 +19,6 @@
 * Michaël Zasso @targos (voting member)
 * Tobias Nießen @tniessen (voting member)
 * Rich Trott @Trott (voting member)
-
 * Beth Griggs @BethGriggs (regular member)
 * Ben Noordhuis @bnoordhuis (regular member)
 * Сковорода Никита Андреевич @ChALkeR (regular member)
@@ -31,5 +30,4 @@
 * Myles Borins @MylesBorins (regular member)
 * Rod Vagg @rvagg (regular member)
 * Tiancheng "Timothy" Gu @TimothyGu (regular member)
-
 * Yagiz Nizipli @anonrig (strategic initiative champion)

--- a/templates/invited_tsc
+++ b/templates/invited_tsc
@@ -31,3 +31,5 @@
 * Myles Borins @MylesBorins (regular member)
 * Rod Vagg @rvagg (regular member)
 * Tiancheng "Timothy" Gu @TimothyGu (regular member)
+
+* Yagiz Nizipli @anonrig (strategic initiative champion)


### PR DESCRIPTION
Yagiz is the champion for the performance strategic initiative. They should be invited to the meetings to give updates or surface anything that is blocking their work. There is no requirement to attend and it would be totally fine for Yagiz to leave updates in the meeting issues as appropriate and never attend at all if they so choose. But they should also have the option to attend if it is useful to them.

@anonrig @nodejs/tsc 