### PR TITLE
Update zoom link in meeting_base_security_collab

### DIFF
--- a/templates/meeting_base_security_collab
+++ b/templates/meeting_base_security_collab
@@ -8,7 +8,7 @@ GROUP_NAME="Security Collab Space"
 AGENDA_TAG=security-agenda
 JOINING_INSTRUCTIONS="
 
-link for participants: Zoom link: <https://zoom.us/j/93954555387>
+link for participants: Zoom link: <https://zoom.us/j/94497273832>
 
 * For those who just want to watch: <https://livestream.openjsf.org>
 


### PR DESCRIPTION
Updates the meeting zoom link to an OpenJS meeting so that we can live stream.