### PR TITLE
updating CPC zoom link to point to calendar

### DIFF
--- a/templates/meeting_base_cross_project_council
+++ b/templates/meeting_base_cross_project_council
@@ -10,7 +10,7 @@ AGENDA_TAG=cross-project-council-agenda
 ISSUE_LABEL=cpc-meeting
 JOINING_INSTRUCTIONS="
 
-link for participants: Zoom link: <https://zoom.us/j/920010234>
+link for participants: Please refer to the <a href="https://calendar.openjsf.org">OpenJS public calendar</a> for meeting link
 
 * For those who just want to watch: <https://livestream.openjsf.org>
 


### PR DESCRIPTION
There is a different zoom link for the two different times that the CPC meets to it seems easiest to simply point to the calendar for the most up to date and accurate link for each meeting.