### PR TITLE
fix(npx): allow usage over `npx`

### DIFF
--- a/bin/create-meeting
+++ b/bin/create-meeting
@@ -11,4 +11,7 @@ if(group === undefined) {
 }
 group = group.toLowerCase() + '-meeting';
 
-spawn('npm', [ 'run', group ], { stdio: 'inherit' });
+spawn('npm', ['run', group], {
+  stdio: 'inherit',
+  cwd: path.join(__dirname, '..')
+});


### PR DESCRIPTION
By setting the cwd explicity, users can run `npx nodejs/create-node-meeting-artifacts [team]`