### PR TITLE
fix: turn off fail fast, let other wg run if one fails

### DIFF
--- a/.github/workflows/create-meeting-artifacts-scheduled.yml
+++ b/.github/workflows/create-meeting-artifacts-scheduled.yml
@@ -8,6 +8,7 @@ jobs:
   create-artifacts:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         meeting_group:
           - benchmarking


### PR DESCRIPTION
In the most recent scheduled run one of the groups [failed](https://github.com/nodejs/create-node-meeting-artifacts/actions/runs/17911852468), this causes all other items in the matrix to cancel, preventing the other wg meeting artifacts from being processed. (it was `userfeedback`, not finding the next calendar invite instance)

Turning off fail fast will allow other matrix members to still execute even if one has failed.