### PR TITLE
chore(issue-generation): remove 'is:open' filter from issue search query

### DIFF
--- a/src/github.mjs
+++ b/src/github.mjs
@@ -65,7 +65,7 @@ export const findIssueByTitle = async (githubClient, title, { properties }) => {
   const githubOrg = properties.USER ?? DEFAULT_CONFIG.githubOrg;
 
   const issues = await githubClient.request('GET /search/issues', {
-    q: `is:open in:title repo:"${githubOrg}/${properties.REPO}" "${title}"`,
+    q: `in:title repo:"${githubOrg}/${properties.REPO}" "${title}"`,
     advanced_search: true,
     per_page: 1,
   });


### PR DESCRIPTION
In the event that a meeting issue is closed _before_ it's creation date, it might be helpful **not** to recreate the issue