### PR TITLE
Add Working Group Updates section to minutes template

### DIFF
--- a/templates/minutes_base_cross_project_council
+++ b/templates/minutes_base_cross_project_council
@@ -41,6 +41,18 @@ Please review regularly our list of dates and reminders, our quarterly review is
 - https://github.com/openjs-foundation/cross-project-council/labels/cpc-quartely-review
 - https://github.com/openjs-foundation/cross-project-council/labels/cpc-can-issue-be-closed
 
+### Working Group Updates
+
+- [ai](https://github.com/openjs-foundation/ai-collab-space)
+- [bundler](https://github.com/openjs-foundation/bundler-collab-space)
+- [ecosystem-report](https://github.com/openjs-foundation/ecosystem-report)
+- [openvis](https://github.com/openjs-foundation/openvis-collab-space)
+- [pkg-metadata-interop](https://github.com/openjs-foundation/package-metadata-interoperability-collab-space)
+- [pkg-vuln](https://github.com/openjs-foundation/pkg-vuln-collab-space)
+- [security](https://github.com/openjs-foundation/security-collab-space)
+- [standards](https://github.com/openjs-foundation/standards)
+- [sustainability](https://github.com/openjs-foundation/sustainability-collab-space)
+
 ### Q&A, Other
 
 ## Upcoming Meetings


### PR DESCRIPTION
Added section for Working Group Updates with links to various collaboration spaces. Per https://github.com/openjs-foundation/cross-project-council/issues/1771#event-25976973674