### PR TITLE
feat(tsc): move to LFX

### DIFF
--- a/templates/meeting_base_tsc
+++ b/templates/meeting_base_tsc
@@ -1,5 +1,5 @@
-CALENDAR_FILTER="Node.js TSC Meeting"
-ICAL_URL="https://calendar.google.com/calendar/ical/c_16f0ae5d3a22625175d199dbdb1cac84c2d09eab7f173e94f558417cb5cdbfd8%40group.calendar.google.com/public/basic.ics"
+CALENDAR_FILTER="Node.js Technical Steering Committee Weekly Meeting"
+ICAL_URL="https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001IV4HSQA1"
 USER="nodejs"
 REPO="TSC"
 HOST="Node.js"
@@ -7,13 +7,12 @@ GROUP_NAME="Technical Steering Committee (TSC)"
 HACKMD_TEAM_NAME="openjs-nodejs"
 JOINING_INSTRUCTIONS="
 
-Zoom link: <https://zoom.us/j/611357642>
-Regular password
+13:00 UTC meeting link: https://zoom-lfx.platform.linuxfoundation.org/meeting/94552847907?password=fbbea37b-f6f4-4dce-bf27-10d3251f0a9c
+17:00 UTC meeting link: https://zoom-lfx.platform.linuxfoundation.org/meeting/96540765177?password=6f3632c7-f3a6-432b-8a27-99c95caffeaa
 
 ## Public participation
 
 We stream our conference call straight to YouTube so anyone can listen to it live, it should start playing at **<https://www.youtube.com/c/nodejs+foundation/live>** when we turn it on. There's usually a short cat-herding time at the start of the meeting and then occasionally we have some quick private business to attend to before we can start recording & streaming. So be patient and it should show up.
-
 
 ---
 


### PR DESCRIPTION
cc @nodejs/tsc

I'm currently working on a better solution than showing both links, but this is the current capability of this tooling.